### PR TITLE
Handle mod keys (ctrl, shift, alt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelogs
+## 0.14.2
+- Keys are handled when right clicking. By default, the right click menu does not show up if a mod key is pressed (ctrl, shift, alt).
+- Allow developer to use the regular right click (https://github.com/nextcloud/files_rightclick/issues/59 thanks to @juliushaertl)
+
 ## 0.13.0
 - Remove regular click option: "Open folder" for example
 - Improve outside clicks detection

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
     <name>Right click</name>
     <summary>Right click menu for Nextcloud</summary>
     <description><![CDATA[This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders.]]></description>
-    <version>0.14.0</version>
+    <version>0.14.2</version>
     <licence>AGPL</licence>
     <author mail="samy@nastuzzi.fr" homepage="https://samy.nastuzzi.fr">NASTUZZI Samy</author>
     <namespace>FilesRightClick</namespace>
@@ -16,7 +16,7 @@
     <documentation>https://github.com/nextcloud/files_rightclick</documentation>
     <screenshot>https://raw.githubusercontent.com/nextcloud/files_rightclick/master/screenshots/picture.png</screenshot>
     <dependencies>
-        <nextcloud min-version="17" max-version="17" />
+        <nextcloud min-version="14" max-version="17" />
     </dependencies>
     <default_enable />
 </info>

--- a/js/script.js
+++ b/js/script.js
@@ -241,7 +241,7 @@ var RightClick = RightClick || {};
                 var targetedEvent = originalEvent || event;
 
                 if (targetedEvent[keyName + 'Key'] && !menu.handledKeys[keyName]) {
-                    return false;
+                    return true;
                 }
             }
 

--- a/js/script.js
+++ b/js/script.js
@@ -13,6 +13,9 @@ var RightClick = RightClick || {};
         openedClass: 'rightClickOpened',
         arrowClass: 'rightClickArrow',
     };
+    exports.handableKeys = [
+        'ctrl', 'shift', 'alt'
+    ];
 
     // Object where all options are listed for one (sub)menu
     exports.Options = function (options) {
@@ -195,12 +198,13 @@ var RightClick = RightClick || {};
     };
 
     exports.menus = [];
-    exports.Menu = function (delimiter, options, context, onClose) {
+    exports.Menu = function (delimiter, options, context, onClose, handledKeys) {
         this.delimiter = $(delimiter);
         this.context = context;
         this.currentContext = undefined;
         this.options = options || new exports.Options();
         this.onClose = onClose;
+
         this.isSubMenu = false;
 
         if (delimiter === undefined)
@@ -219,7 +223,28 @@ var RightClick = RightClick || {};
             return this.element !== undefined;
         }
 
+        this.handleKeys = function (handledKeys) {
+            this.handledKeys = {};
+            handledKeys = handledKeys || {};
+
+            for (var key in exports.handableKeys) {
+                var keyName = exports.handableKeys[key];
+
+                this.handledKeys[keyName] = handledKeys[keyName] || false;
+            }
+        };
+        this.handleKeys(handledKeys);
+
         var onClick = function (event, originalEvent) {
+            for (var key in exports.handableKeys) {
+                var keyName = exports.handableKeys[key];
+                var targetedEvent = originalEvent || event;
+
+                if (targetedEvent[keyName + 'Key'] && !menu.handledKeys[keyName]) {
+                    return false;
+                }
+            }
+
             event.stopPropagation();
             event.preventDefault();
 


### PR DESCRIPTION
Tested on Firefox and Chromium
Fix: https://github.com/nextcloud/files_rightclick/issues/59

PS: On Firefox, Shift + Right click will always open the context menu :) 