### PR TITLE
Replace arrow function with regular function for wider compatibility

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -338,7 +338,9 @@ var RightClick = RightClick || {};
             if (optionsDisabled)
                 menu.element.css('background-color', '#AAA');
 
-            menu.element.on('contextmenu', () => false);
+            menu.element.on('contextmenu', function () {
+                return false;
+            });
             menu.element.on('mouseleave', function (event) {
                 if (menu.isOpenedOnHover)
                     menu.close();


### PR DESCRIPTION
Some older browsers, like Internet Explorer 11, do not support arrow functions. As it was just a single occurrence the arrow function was replaced with a regular function to make the code compatible with older browsers.
