### PR TITLE
Added padding when menu is opened to prevent horizontal jumping

### DIFF
--- a/css/app.css
+++ b/css/app.css
@@ -26,4 +26,21 @@
 .rightClickOpened {
     height: 100% !important;
     overflow: hidden !important;
+    padding: 0 12px 0 0;
+}
+.rightClickOpenedFF {
+    padding: 0 8px 0 0;
+}
+.openedHorizontalShift {
+  padding: 0 12px 0 0;
+}
+.openedHorizontalShiftFF {
+  padding: 0 8px 0 0;
+}
+/* separate padding values for the view-toggle element as it already has padding */
+.view-togglePadding {
+  padding: 22px 46px 22px 22px!important; /* Maths genius */
+}
+.view-togglePaddingFF {
+  padding: 22px 38px 22px 22px!important;
 }

--- a/js/script.js
+++ b/js/script.js
@@ -11,6 +11,10 @@ var RightClick = RightClick || {};
         menuClass: 'rightClickMenu',
         subMenuClass: 'rightClickSubMenu',
         openedClass: 'rightClickOpened',
+        openedShiftClass: 'openedHorizontalShift',
+        openedShiftClassFF: 'openedHorizontalShiftFF',
+        openedVTPaddingClass: 'view-togglePadding',
+        openedVTPaddingClassFF: 'view-togglePaddingFF',
         arrowClass: 'rightClickArrow',
     };
     exports.handableKeys = [
@@ -438,6 +442,18 @@ var RightClick = RightClick || {};
         if (!exports.isAMenuOpened()) {
             $(window).on('resize', exports.closeAllMenus);
             $('body').addClass(exports.selectors.openedClass);
+            //Add padding to elements to stop page jumping on right click
+            if(navigator.userAgent.match(/firefox|fxios/i)){ // More if statements can be added for other browsers with elseif
+              console.log('Match');
+             $('body').addClass(exports.selectors.openedShiftClassFF);
+             $('#header').addClass(exports.selectors.openedShiftClassFF);
+             $('#view-toggle').addClass(exports.selectors.openedVTPaddingClassFF);
+           } else {
+             console.log('No match');
+             $('#header').addClass(exports.selectors.openedShiftClass);
+             $('body').addClass(exports.selectors.openedShiftClass);
+             $('#view-toggle').addClass(exports.selectors.openedVTPaddingClass);
+           }
         }
 
         $('#' + exports.selectors.detectorId).css('display', 'block');
@@ -466,6 +482,14 @@ var RightClick = RightClick || {};
         if (!exports.isAMenuOpened()) {
             $(window).off('resize', exports.closeAllMenus);
             $('body').removeClass(exports.selectors.openedClass);
+            //Remove padding shift classes
+            $('#header').removeClass(exports.selectors.openedShiftClass);
+            $('body').removeClass(exports.selectors.openedShiftClass);
+            $('#view-toggle').removeClass(exports.selectors.openedVTPaddingClass);
+            //Specific for Firefox
+            $('#header').removeClass(exports.selectors.openedShiftClassFF);
+            $('body').removeClass(exports.selectors.openedShiftClassFF);
+            $('#view-toggle').removeClass(exports.selectors.openedVTPaddingClassFF);
             $('#' + exports.selectors.detectorId).css('display', 'none');
 
             return true;


### PR DESCRIPTION
Really simply adds a 12px padding to the right (8px for Firefox) which keeps the content in place when you are right clicking

Simply because it's jarring to see it jumping when you right click due to the scrollbar being hidden

 Signed-off-by:  Tom Gibbs <tom@freesphere.com>