### PR TITLE
Open Menu outside hover File&Folder 

### DIFF
--- a/.github/workflows/block-merge-freeze.yml
+++ b/.github/workflows/block-merge-freeze.yml
@@ -1,0 +1,21 @@
+# This workflow is provided via the organization template repository
+#
+# https://github.com/nextcloud/.github
+# https://docs.github.com/en/actions/learn-github-actions/sharing-workflows-with-your-organization
+
+name: Pull request checks
+
+on: pull_request
+
+jobs:
+  block-merges-during-freeze:
+    name: Block merges during freezes
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download version.php from ${{ github.base_ref }}
+        run: curl https://raw.githubusercontent.com/nextcloud/server/${{ github.base_ref }}/version.php --output version.php
+
+      - name: Run check
+        run: cat version.php | grep 'OC_VersionString' | grep -i -v 'RC'

--- a/.tx/config
+++ b/.tx/config
@@ -1,9 +1,10 @@
 [main]
-host = https://www.transifex.com
-lang_map = bg_BG: bg, cs_CZ: cs, fi_FI: fi, hu_HU: hu, nb_NO: nb, sk_SK: sk, th_TH: th, ja_JP: ja
+host     = https://www.transifex.com
+lang_map = th_TH: th, ja_JP: ja, bg_BG: bg, cs_CZ: cs, fi_FI: fi, hu_HU: hu, nb_NO: nb, sk_SK: sk
 
-[nextcloud.files_rightclick]
+[o:nextcloud:p:nextcloud:r:files_rightclick]
 file_filter = translationfiles/<lang>/files_rightclick.po
 source_file = translationfiles/templates/files_rightclick.pot
 source_lang = en
-type = PO
+type        = PO
+

--- a/l10n/bg.js
+++ b/l10n/bg.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Размаркирай",
+    "Share folder" : "Споделяне на папка",
+    "Share file" : "Споделяне на файл",
     "Select" : "Избери",
     "Copied !" : "Копирано!",
     "Right click" : "Десен бутон",

--- a/l10n/bg.json
+++ b/l10n/bg.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Размаркирай",
+    "Share folder" : "Споделяне на папка",
+    "Share file" : "Споделяне на файл",
     "Select" : "Избери",
     "Copied !" : "Копирано!",
     "Right click" : "Десен бутон",

--- a/l10n/ca.js
+++ b/l10n/ca.js
@@ -2,10 +2,12 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Anul·la la selecció",
+    "Share folder" : "Comparteix la carpeta",
+    "Share file" : "Comparteix el fitxer",
     "Select" : "Selecciona",
     "Copied !" : "S'ha copiat!",
     "Right click" : "Clic amb el botó dret",
-    "Right click menu for Nextcloud" : "Menú de clic dret per al Nextcloud",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Aquesta aplicació permet que usuaris i desenvolupadors disposin d'un menú fent clic amb el botó dret. Simplement feu servir l'objecte RightClick per crear menús contextuals ràpidament. L'aplicació Fitxers ja mostra el menú d'accions en fer clic amb el botó dret sobre fitxers i carpetes."
+    "Right click menu for Nextcloud" : "Menú de clic amb el botó dret per al Nextcloud",
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Aquesta aplicació permet que usuaris i desenvolupadors disposin d'un menú de clic amb el botó dret. Només cal que utilitzeu l'objecte RightClick per a crear menús contextuals ràpidament. L'aplicació Fitxers ja mostra el menú d'accions en fer clic amb el botó dret sobre fitxers i carpetes."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/ca.json
+++ b/l10n/ca.json
@@ -1,9 +1,11 @@
 { "translations": {
     "Unselect" : "Anul·la la selecció",
+    "Share folder" : "Comparteix la carpeta",
+    "Share file" : "Comparteix el fitxer",
     "Select" : "Selecciona",
     "Copied !" : "S'ha copiat!",
     "Right click" : "Clic amb el botó dret",
-    "Right click menu for Nextcloud" : "Menú de clic dret per al Nextcloud",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Aquesta aplicació permet que usuaris i desenvolupadors disposin d'un menú fent clic amb el botó dret. Simplement feu servir l'objecte RightClick per crear menús contextuals ràpidament. L'aplicació Fitxers ja mostra el menú d'accions en fer clic amb el botó dret sobre fitxers i carpetes."
+    "Right click menu for Nextcloud" : "Menú de clic amb el botó dret per al Nextcloud",
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Aquesta aplicació permet que usuaris i desenvolupadors disposin d'un menú de clic amb el botó dret. Només cal que utilitzeu l'objecte RightClick per a crear menús contextuals ràpidament. L'aplicació Fitxers ja mostra el menú d'accions en fer clic amb el botó dret sobre fitxers i carpetes."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/cs.js
+++ b/l10n/cs.js
@@ -2,8 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Zrušit výběr",
-    "Share folder" : "Sdílet složku",
-    "Share file" : "Sdílet soubor",
+    "Share folder" : "Nasdílet složku",
+    "Share file" : "Nasdílet soubor",
     "Select" : "Označit",
     "Copied !" : "Zkopírováno",
     "Right click" : "Kliknutí pravým tlačítkem myši",

--- a/l10n/cs.json
+++ b/l10n/cs.json
@@ -1,7 +1,7 @@
 { "translations": {
     "Unselect" : "Zrušit výběr",
-    "Share folder" : "Sdílet složku",
-    "Share file" : "Sdílet soubor",
+    "Share folder" : "Nasdílet složku",
+    "Share file" : "Nasdílet soubor",
     "Select" : "Označit",
     "Copied !" : "Zkopírováno",
     "Right click" : "Kliknutí pravým tlačítkem myši",

--- a/l10n/da.js
+++ b/l10n/da.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Fravælg",
+    "Share folder" : "Del mappe",
+    "Share file" : "Del fil",
     "Select" : "Vælg",
     "Copied !" : "Kopieret !",
     "Right click" : "Højre klik",

--- a/l10n/da.json
+++ b/l10n/da.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Fravælg",
+    "Share folder" : "Del mappe",
+    "Share file" : "Del fil",
     "Select" : "Vælg",
     "Copied !" : "Kopieret !",
     "Right click" : "Højre klik",

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Abwählen",
+    "Share folder" : "Ordner teilen",
+    "Share file" : "Datei teilen",
     "Select" : "Auswählen",
     "Copied !" : "Kopiert!",
     "Right click" : "Rechtsklick",

--- a/l10n/de.js
+++ b/l10n/de.js
@@ -8,6 +8,6 @@ OC.L10N.register(
     "Copied !" : "Kopiert!",
     "Right click" : "Rechtsklick",
     "Right click menu for Nextcloud" : "Kontextmenü für Nextcloud",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Diese App ermöglicht es Benutzern, aber auch Entwicklern, ein Rechtsklickmenü zu haben. Verwende einfach das RightClick-Objekt, um schnell und einfach Menüs zu erstellen. Die Datei-App zeigt bereits das Aktionsmenü an, wenn Du mit der rechten Maustaste auf Dateien und Ordner klicken."
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Diese App ermöglicht es Benutzern, aber auch Entwicklern, ein Rechtsklickmenü zu haben. Verwende einfach das RightClick-Objekt, um schnell und einfach Menüs zu erstellen. Die Datei-App zeigt bereits das Aktionsmenü an, wenn du mit der rechten Maustaste auf Dateien und Ordner klicken."
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Abwählen",
+    "Share folder" : "Ordner teilen",
+    "Share file" : "Datei teilen",
     "Select" : "Auswählen",
     "Copied !" : "Kopiert!",
     "Right click" : "Rechtsklick",

--- a/l10n/de.json
+++ b/l10n/de.json
@@ -6,6 +6,6 @@
     "Copied !" : "Kopiert!",
     "Right click" : "Rechtsklick",
     "Right click menu for Nextcloud" : "Kontextmenü für Nextcloud",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Diese App ermöglicht es Benutzern, aber auch Entwicklern, ein Rechtsklickmenü zu haben. Verwende einfach das RightClick-Objekt, um schnell und einfach Menüs zu erstellen. Die Datei-App zeigt bereits das Aktionsmenü an, wenn Du mit der rechten Maustaste auf Dateien und Ordner klicken."
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Diese App ermöglicht es Benutzern, aber auch Entwicklern, ein Rechtsklickmenü zu haben. Verwende einfach das RightClick-Objekt, um schnell und einfach Menüs zu erstellen. Die Datei-App zeigt bereits das Aktionsmenü an, wenn du mit der rechten Maustaste auf Dateien und Ordner klicken."
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/en_GB.js
+++ b/l10n/en_GB.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Unselect",
+    "Share folder" : "Share folder",
+    "Share file" : "Share file",
     "Select" : "Select",
     "Copied !" : "Copied !",
     "Right click" : "Right click",

--- a/l10n/en_GB.json
+++ b/l10n/en_GB.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Unselect",
+    "Share folder" : "Share folder",
+    "Share file" : "Share file",
     "Select" : "Select",
     "Copied !" : "Copied !",
     "Right click" : "Right click",

--- a/l10n/es.js
+++ b/l10n/es.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menú de clic derecho para Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Esta app permite a usuarios y desarrolladores tener un menú de clic derecho. Simplemente, usa el objeto RightClick para crear rápidamente menús contextuales. La app de Archivos ya muestra el menú de acciones al hacer clic derecho en archivos y carpetas."
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es.json
+++ b/l10n/es.json
@@ -7,5 +7,5 @@
     "Right click" : "Clic derecho (Right click)",
     "Right click menu for Nextcloud" : "Menú de clic derecho para Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Esta app permite a usuarios y desarrolladores tener un menú de clic derecho. Simplemente, usa el objeto RightClick para crear rápidamente menús contextuales. La app de Archivos ya muestra el menú de acciones al hacer clic derecho en archivos y carpetas."
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_419.js
+++ b/l10n/es_419.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_419.json
+++ b/l10n/es_419.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_AR.js
+++ b/l10n/es_AR.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_AR.json
+++ b/l10n/es_AR.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_CL.js
+++ b/l10n/es_CL.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_CL.json
+++ b/l10n/es_CL.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_CO.js
+++ b/l10n/es_CO.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_CO.json
+++ b/l10n/es_CO.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_CR.js
+++ b/l10n/es_CR.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_CR.json
+++ b/l10n/es_CR.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_DO.js
+++ b/l10n/es_DO.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_DO.json
+++ b/l10n/es_DO.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_EC.js
+++ b/l10n/es_EC.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_EC.json
+++ b/l10n/es_EC.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_GT.js
+++ b/l10n/es_GT.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_GT.json
+++ b/l10n/es_GT.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_HN.js
+++ b/l10n/es_HN.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_HN.json
+++ b/l10n/es_HN.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_MX.js
+++ b/l10n/es_MX.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_MX.json
+++ b/l10n/es_MX.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_NI.js
+++ b/l10n/es_NI.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_NI.json
+++ b/l10n/es_NI.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_PA.js
+++ b/l10n/es_PA.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_PA.json
+++ b/l10n/es_PA.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_PE.js
+++ b/l10n/es_PE.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_PE.json
+++ b/l10n/es_PE.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_PR.js
+++ b/l10n/es_PR.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_PR.json
+++ b/l10n/es_PR.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_PY.js
+++ b/l10n/es_PY.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_PY.json
+++ b/l10n/es_PY.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_SV.js
+++ b/l10n/es_SV.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=2; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_SV.js
+++ b/l10n/es_SV.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_SV.json
+++ b/l10n/es_SV.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_SV.json
+++ b/l10n/es_SV.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=2; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/es_UY.js
+++ b/l10n/es_UY.js
@@ -3,4 +3,4 @@ OC.L10N.register(
     {
     "Select" : "Seleccionar"
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/es_UY.json
+++ b/l10n/es_UY.json
@@ -1,4 +1,4 @@
 { "translations": {
     "Select" : "Seleccionar"
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/fa.js
+++ b/l10n/fa.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "لغو انتخاب",
+    "Share folder" : "اشتراک‌گذاری پوشه",
+    "Share file" : "اشتراک‌گذاری پرونده",
     "Select" : "انتخاب",
     "Copied !" : "کپی شد!",
     "Right click" : "کلیک راست",

--- a/l10n/fa.json
+++ b/l10n/fa.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "لغو انتخاب",
+    "Share folder" : "اشتراک‌گذاری پوشه",
+    "Share file" : "اشتراک‌گذاری پرونده",
     "Select" : "انتخاب",
     "Copied !" : "کپی شد!",
     "Right click" : "کلیک راست",

--- a/l10n/fi.js
+++ b/l10n/fi.js
@@ -6,8 +6,8 @@ OC.L10N.register(
     "Share file" : "Jaa tiedosto",
     "Select" : "Valitse",
     "Copied !" : "Kopioitu!",
-    "Right click" : "Oikea Klikkaus",
-    "Right click menu for Nextcloud" : "Right click valikko Nextcloudille",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Tämä sovellus mahdollistaa käyttäjille ja kehittäjille laittaa oman right click valikon. Käytä RightClick objektia nopean menun luomiseen.\nTiedostot sovelluksessa on jo Right click menu, kun klikkaat oikeaa hiirellä tiedostojen ja kansioiden kohdalla "
+    "Right click" : "Oikea napsautus",
+    "Right click menu for Nextcloud" : "Oikean napsautuksen valikko Nextcloudille",
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Tämä sovellus mahdollistaa käyttäjille ja kehittäjille asettaa oman oikean napsautuksen valikon. Käytä RightClick-objektia  luodaksesi kontekstivalikkoja.\nTiedostot-sovelluksessa on jo toimintovalikko, kun napsautat tiedostojen ja kansioiden kohdalla hiiren oikealla painikkeella. "
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/fi.json
+++ b/l10n/fi.json
@@ -4,8 +4,8 @@
     "Share file" : "Jaa tiedosto",
     "Select" : "Valitse",
     "Copied !" : "Kopioitu!",
-    "Right click" : "Oikea Klikkaus",
-    "Right click menu for Nextcloud" : "Right click valikko Nextcloudille",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Tämä sovellus mahdollistaa käyttäjille ja kehittäjille laittaa oman right click valikon. Käytä RightClick objektia nopean menun luomiseen.\nTiedostot sovelluksessa on jo Right click menu, kun klikkaat oikeaa hiirellä tiedostojen ja kansioiden kohdalla "
+    "Right click" : "Oikea napsautus",
+    "Right click menu for Nextcloud" : "Oikean napsautuksen valikko Nextcloudille",
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Tämä sovellus mahdollistaa käyttäjille ja kehittäjille asettaa oman oikean napsautuksen valikon. Käytä RightClick-objektia  luodaksesi kontekstivalikkoja.\nTiedostot-sovelluksessa on jo toimintovalikko, kun napsautat tiedostojen ja kansioiden kohdalla hiiren oikealla painikkeella. "
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menu clic droit pour Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Cette application permet aux utilisateurs et développeurs de disposer d'un menu réagissant au clic-droit. Utilisez simplement l'objet 'RightClick' (clic-droit) pour créer rapidement des menus contextuels. L'application 'Files' (Fichiers) propose déjà un menu d'actions contextuelles lorsque l'on  clique-droit sur les fichiers ou dossiers."
 },
-"nplurals=3; plural=(n==0 || n==1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");
+"nplurals=2; plural=(n > 1);");

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menu clic droit pour Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Cette application permet aux utilisateurs et développeurs de disposer d'un menu réagissant au clic-droit. Utilisez simplement l'objet 'RightClick' (clic-droit) pour créer rapidement des menus contextuels. L'application 'Files' (Fichiers) propose déjà un menu d'actions contextuelles lorsque l'on  clique-droit sur les fichiers ou dossiers."
 },
-"nplurals=2; plural=(n > 1);");
+"nplurals=3; plural=(n==0 || n==1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/fr.js
+++ b/l10n/fr.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menu clic droit pour Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Cette application permet aux utilisateurs et développeurs de disposer d'un menu réagissant au clic-droit. Utilisez simplement l'objet 'RightClick' (clic-droit) pour créer rapidement des menus contextuels. L'application 'Files' (Fichiers) propose déjà un menu d'actions contextuelles lorsque l'on  clique-droit sur les fichiers ou dossiers."
 },
-"nplurals=2; plural=(n > 1);");
+"nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -7,5 +7,5 @@
     "Right click" : "Clic droit",
     "Right click menu for Nextcloud" : "Menu clic droit pour Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Cette application permet aux utilisateurs et développeurs de disposer d'un menu réagissant au clic-droit. Utilisez simplement l'objet 'RightClick' (clic-droit) pour créer rapidement des menus contextuels. L'application 'Files' (Fichiers) propose déjà un menu d'actions contextuelles lorsque l'on  clique-droit sur les fichiers ou dossiers."
-},"pluralForm" :"nplurals=3; plural=(n==0 || n==1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
+},"pluralForm" :"nplurals=2; plural=(n > 1);"
 }

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -7,5 +7,5 @@
     "Right click" : "Clic droit",
     "Right click menu for Nextcloud" : "Menu clic droit pour Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Cette application permet aux utilisateurs et développeurs de disposer d'un menu réagissant au clic-droit. Utilisez simplement l'objet 'RightClick' (clic-droit) pour créer rapidement des menus contextuels. L'application 'Files' (Fichiers) propose déjà un menu d'actions contextuelles lorsque l'on  clique-droit sur les fichiers ou dossiers."
-},"pluralForm" :"nplurals=2; plural=(n > 1);"
+},"pluralForm" :"nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/fr.json
+++ b/l10n/fr.json
@@ -7,5 +7,5 @@
     "Right click" : "Clic droit",
     "Right click menu for Nextcloud" : "Menu clic droit pour Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Cette application permet aux utilisateurs et développeurs de disposer d'un menu réagissant au clic-droit. Utilisez simplement l'objet 'RightClick' (clic-droit) pour créer rapidement des menus contextuels. L'application 'Files' (Fichiers) propose déjà un menu d'actions contextuelles lorsque l'on  clique-droit sur les fichiers ou dossiers."
-},"pluralForm" :"nplurals=2; plural=(n > 1);"
+},"pluralForm" :"nplurals=3; plural=(n==0 || n==1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/hr.js
+++ b/l10n/hr.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Poništi odabir",
+    "Share folder" : "Dijeli mapu",
+    "Share file" : "Dijeli datoteku",
     "Select" : "Odaberi",
     "Copied !" : "Kopirano!",
     "Right click" : "Desni klik",

--- a/l10n/hr.json
+++ b/l10n/hr.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Poništi odabir",
+    "Share folder" : "Dijeli mapu",
+    "Share file" : "Dijeli datoteku",
     "Select" : "Odaberi",
     "Copied !" : "Kopirano!",
     "Right click" : "Desni klik",

--- a/l10n/it.js
+++ b/l10n/it.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menu del tasto destro per Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Questa applicazione consente a utenti e sviluppatori di avere un menu per il tasto destro. Utilizza semplicemente l'oggetto RightClick per creare rapidamente menu contestuali. L'applicazione File mostra già il menu delle azioni quando fai clic su file e cartelle."
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/it.json
+++ b/l10n/it.json
@@ -7,5 +7,5 @@
     "Right click" : "Clic destro",
     "Right click menu for Nextcloud" : "Menu del tasto destro per Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Questa applicazione consente a utenti e sviluppatori di avere un menu per il tasto destro. Utilizza semplicemente l'oggetto RightClick per creare rapidamente menu contestuali. L'applicazione File mostra già il menu delle azioni quando fai clic su file e cartelle."
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/ja.js
+++ b/l10n/ja.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "選択解除",
+    "Share folder" : "フォルダーを共有",
+    "Share file" : "ファイルを共有",
     "Select" : "選択",
     "Copied !" : "コピーしました",
     "Right click" : "右クリック",

--- a/l10n/ja.json
+++ b/l10n/ja.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "選択解除",
+    "Share folder" : "フォルダーを共有",
+    "Share file" : "ファイルを共有",
     "Select" : "選択",
     "Copied !" : "コピーしました",
     "Right click" : "右クリック",

--- a/l10n/lo.js
+++ b/l10n/lo.js
@@ -1,7 +1,6 @@
 OC.L10N.register(
     "files_rightclick",
     {
-    "Unselect" : "Bỏ chọn",
-    "Select" : "Select"
+    "Select" : "ເລືອກ"
 },
 "nplurals=1; plural=0;");

--- a/l10n/lo.json
+++ b/l10n/lo.json
@@ -1,5 +1,4 @@
 { "translations": {
-    "Unselect" : "Bỏ chọn",
-    "Select" : "Select"
+    "Select" : "ເລືອກ"
 },"pluralForm" :"nplurals=1; plural=0;"
 }

--- a/l10n/lt_LT.js
+++ b/l10n/lt_LT.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Nuimti žymėjimą",
+    "Share folder" : "Bendrinti aplanką",
+    "Share file" : "Bendrinti failą",
     "Select" : "Žymėti",
     "Copied !" : "Nukopijuota!"
 },

--- a/l10n/lt_LT.json
+++ b/l10n/lt_LT.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Nuimti žymėjimą",
+    "Share folder" : "Bendrinti aplanką",
+    "Share file" : "Bendrinti failą",
     "Select" : "Žymėti",
     "Copied !" : "Nukopijuota!"
 },"pluralForm" :"nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < 11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : n % 1 != 0 ? 2: 3);"

--- a/l10n/nb.js
+++ b/l10n/nb.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Velg bort",
+    "Share folder" : "Del mappe",
+    "Share file" : "Del fil",
     "Select" : "Velg",
     "Copied !" : "Kopiert!",
     "Right click" : "Høyreklikk",

--- a/l10n/nb.json
+++ b/l10n/nb.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Velg bort",
+    "Share folder" : "Del mappe",
+    "Share file" : "Del fil",
     "Select" : "Velg",
     "Copied !" : "Kopiert!",
     "Right click" : "Høyreklikk",

--- a/l10n/pt_BR.js
+++ b/l10n/pt_BR.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menu no botão direito para Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Este aplicativo permite que usuários e desenvolvedores tenham um menu no botão direito. Basta usar o objeto RightClick para criar rapidamente menus de contexto. O aplicativo Arquivos já mostra o menu de ações ao clicar com o botão direito em arquivos e pastas."
 },
-"nplurals=2; plural=(n > 1);");
+"nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/pt_BR.json
+++ b/l10n/pt_BR.json
@@ -7,5 +7,5 @@
     "Right click" : "Clique direito",
     "Right click menu for Nextcloud" : "Menu no botão direito para Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Este aplicativo permite que usuários e desenvolvedores tenham um menu no botão direito. Basta usar o objeto RightClick para criar rapidamente menus de contexto. O aplicativo Arquivos já mostra o menu de ações ao clicar com o botão direito em arquivos e pastas."
-},"pluralForm" :"nplurals=2; plural=(n > 1);"
+},"pluralForm" :"nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/pt_PT.js
+++ b/l10n/pt_PT.js
@@ -1,6 +1,13 @@
 OC.L10N.register(
     "files_rightclick",
     {
-    "Select" : "Seleccionar"
+    "Unselect" : "Não selecionar",
+    "Share folder" : "Partilhar pasta",
+    "Share file" : "Partilhar ficheiro",
+    "Select" : "Selecionar",
+    "Copied !" : "Copiado!",
+    "Right click" : "Clique lado direito",
+    "Right click menu for Nextcloud" : "Menu lado direito para Nextcloud",
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Esta aplicação permite que utilizadores e desenvolvedores tenham um menu do botão direito. Basta usar o objeto RightClick para criar menus de contexto rapidamente. A aplicação Ficheiros já mostra o menu de ações ao clicar com o botão direito em ficheiros e pastas. "
 },
 "nplurals=2; plural=(n != 1);");

--- a/l10n/pt_PT.js
+++ b/l10n/pt_PT.js
@@ -10,4 +10,4 @@ OC.L10N.register(
     "Right click menu for Nextcloud" : "Menu lado direito para Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Esta aplicação permite que utilizadores e desenvolvedores tenham um menu do botão direito. Basta usar o objeto RightClick para criar menus de contexto rapidamente. A aplicação Ficheiros já mostra o menu de ações ao clicar com o botão direito em ficheiros e pastas. "
 },
-"nplurals=2; plural=(n != 1);");
+"nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/l10n/pt_PT.json
+++ b/l10n/pt_PT.json
@@ -1,4 +1,11 @@
 { "translations": {
-    "Select" : "Seleccionar"
+    "Unselect" : "Não selecionar",
+    "Share folder" : "Partilhar pasta",
+    "Share file" : "Partilhar ficheiro",
+    "Select" : "Selecionar",
+    "Copied !" : "Copiado!",
+    "Right click" : "Clique lado direito",
+    "Right click menu for Nextcloud" : "Menu lado direito para Nextcloud",
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Esta aplicação permite que utilizadores e desenvolvedores tenham um menu do botão direito. Basta usar o objeto RightClick para criar menus de contexto rapidamente. A aplicação Ficheiros já mostra o menu de ações ao clicar com o botão direito em ficheiros e pastas. "
 },"pluralForm" :"nplurals=2; plural=(n != 1);"
 }

--- a/l10n/pt_PT.json
+++ b/l10n/pt_PT.json
@@ -7,5 +7,5 @@
     "Right click" : "Clique lado direito",
     "Right click menu for Nextcloud" : "Menu lado direito para Nextcloud",
     "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Esta aplicação permite que utilizadores e desenvolvedores tenham um menu do botão direito. Basta usar o objeto RightClick para criar menus de contexto rapidamente. A aplicação Ficheiros já mostra o menu de ações ao clicar com o botão direito em ficheiros e pastas. "
-},"pluralForm" :"nplurals=2; plural=(n != 1);"
+},"pluralForm" :"nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
 }

--- a/l10n/ru.js
+++ b/l10n/ru.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Снять выбор",
+    "Share folder" : "Поделиться папкой",
+    "Share file" : "Поделиться файлом",
     "Select" : "Выбрать",
     "Copied !" : "Скопировано !",
     "Right click" : "Правая кнопка мыши",

--- a/l10n/ru.json
+++ b/l10n/ru.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Снять выбор",
+    "Share folder" : "Поделиться папкой",
+    "Share file" : "Поделиться файлом",
     "Select" : "Выбрать",
     "Copied !" : "Скопировано !",
     "Right click" : "Правая кнопка мыши",

--- a/l10n/sl.js
+++ b/l10n/sl.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Odstrani izbor",
+    "Share folder" : "Omogoči souporabo mape",
+    "Share file" : "Omogoči souporabo datoteke",
     "Select" : "Izberi",
     "Copied !" : "Kopirano!",
     "Right click" : "Desni klik",

--- a/l10n/sl.json
+++ b/l10n/sl.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Odstrani izbor",
+    "Share folder" : "Omogoči souporabo mape",
+    "Share file" : "Omogoči souporabo datoteke",
     "Select" : "Izberi",
     "Copied !" : "Kopirano!",
     "Right click" : "Desni klik",

--- a/l10n/sv.js
+++ b/l10n/sv.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Avmarkera",
+    "Share folder" : "Dela mapp",
+    "Share file" : "Dela fil",
     "Select" : "Välj",
     "Copied !" : "Kopierat!",
     "Right click" : "Högerklick",

--- a/l10n/sv.json
+++ b/l10n/sv.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Avmarkera",
+    "Share folder" : "Dela mapp",
+    "Share file" : "Dela fil",
     "Select" : "Välj",
     "Copied !" : "Kopierat!",
     "Right click" : "Högerklick",

--- a/l10n/uk.js
+++ b/l10n/uk.js
@@ -2,6 +2,8 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Зняти виділення",
+    "Share folder" : "Спільний доступ до папки",
+    "Share file" : "Поділитися файлом",
     "Select" : "Вибрати",
     "Copied !" : "Скопійовано!",
     "Right click" : "Права кнопка",

--- a/l10n/uk.js
+++ b/l10n/uk.js
@@ -2,12 +2,12 @@ OC.L10N.register(
     "files_rightclick",
     {
     "Unselect" : "Зняти виділення",
-    "Share folder" : "Спільний доступ до папки",
+    "Share folder" : "Спільний доступ для каталогу",
     "Share file" : "Поділитися файлом",
     "Select" : "Вибрати",
     "Copied !" : "Скопійовано!",
     "Right click" : "Права кнопка",
     "Right click menu for Nextcloud" : "Меню правої кнопки для Nextcloud",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Цей застосунок дозволяє користувачам і розробникам створювати і використовувати меню правої кнопки. Використовуйте об'єкт RightClick для швидкого створення контекстного меню. У застосунку Файли меню правої кнопки вже використовується для файлів і тек."
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Цей застосунок дозволяє користувачам та розробникам створювати та використовувати меню правої кнопки миші. Використовуйте об'єкт RightClick для швидкого створення контекстного меню. У застосунку \"Файли\" меню правої кнопки вже використовується для файлів і каталогів."
 },
 "nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);");

--- a/l10n/uk.json
+++ b/l10n/uk.json
@@ -1,11 +1,11 @@
 { "translations": {
     "Unselect" : "Зняти виділення",
-    "Share folder" : "Спільний доступ до папки",
+    "Share folder" : "Спільний доступ для каталогу",
     "Share file" : "Поділитися файлом",
     "Select" : "Вибрати",
     "Copied !" : "Скопійовано!",
     "Right click" : "Права кнопка",
     "Right click menu for Nextcloud" : "Меню правої кнопки для Nextcloud",
-    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Цей застосунок дозволяє користувачам і розробникам створювати і використовувати меню правої кнопки. Використовуйте об'єкт RightClick для швидкого створення контекстного меню. У застосунку Файли меню правої кнопки вже використовується для файлів і тек."
+    "This app allows users and developers to have a right click menu. Simply use the RightClick object to quickly create context menus. The Files app already shows the actions menu when right clicking on files and folders." : "Цей застосунок дозволяє користувачам та розробникам створювати та використовувати меню правої кнопки миші. Використовуйте об'єкт RightClick для швидкого створення контекстного меню. У застосунку \"Файли\" меню правої кнопки вже використовується для файлів і каталогів."
 },"pluralForm" :"nplurals=4; plural=(n % 1 == 0 && n % 10 == 1 && n % 100 != 11 ? 0 : n % 1 == 0 && n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14) ? 1 : n % 1 == 0 && (n % 10 ==0 || (n % 10 >=5 && n % 10 <=9) || (n % 100 >=11 && n % 100 <=14 )) ? 2: 3);"
 }

--- a/l10n/uk.json
+++ b/l10n/uk.json
@@ -1,5 +1,7 @@
 { "translations": {
     "Unselect" : "Зняти виділення",
+    "Share folder" : "Спільний доступ до папки",
+    "Share file" : "Поділитися файлом",
     "Select" : "Вибрати",
     "Copied !" : "Скопійовано!",
     "Right click" : "Права кнопка",

--- a/l10n/uz.js
+++ b/l10n/uz.js
@@ -1,0 +1,6 @@
+OC.L10N.register(
+    "files_rightclick",
+    {
+    "Select" : "Select"
+},
+"nplurals=1; plural=0;");

--- a/l10n/uz.json
+++ b/l10n/uz.json
@@ -1,0 +1,4 @@
+{ "translations": {
+    "Select" : "Select"
+},"pluralForm" :"nplurals=1; plural=0;"
+}


### PR DESCRIPTION
Everytime the mouse is hover some file or folder the menu opens correctly, but there is no menu outside that area. In the blank space below a list of files or folders the menu could open the default folder menu: "create new folder, send new file, create new file and other stuff"