### PR TITLE
fix multiselect right-click options

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -63,7 +63,7 @@
                 $(currentFile.find('input.selectCheckBox')).click();
             });
 
-            $.each($('.selectedActions .menu-center li'), function (i, selectedAction) {
+            $.each($('.selectedActions .menu-center li:not(.hidden)'), function (i, selectedAction) {
                 var action = $(selectedAction);
 
                 addNewOption(action.attr('class'), $(action.find('span.icon')).attr('class').replace('icon', '').replace(' ', '').replace('icon-', ''), $(action.find('span:not(.icon)')).text(), function () {


### PR DESCRIPTION
To reproduce:
1. share a folder with a user anna
2. remove the delete permission
3. open the folder with the user anna
4. multi-select the file
5. see the delete option even though there are no delete permissions

| Before | After |
|---|---|
| ![image](https://user-images.githubusercontent.com/42591237/225928258-61f320c7-d03d-46e2-9059-a4ebfb072510.png) | ![image](https://user-images.githubusercontent.com/42591237/225928239-6d44069d-320a-4fd3-b947-8a13ffe38157.png) |

<details>
<summary>For my own testing</summary>

```
docker run -it \
--name nextcloud-easy-test \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.24.128 \
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" \
-e SERVER_BRANCH=master \
-e RIGHTCLICK_BRANCH=enh/noid/fix-multiselect-right-click \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>