### PR TITLE
fix right-click-menu for open locally

### DIFF
--- a/js/files.js
+++ b/js/files.js
@@ -66,7 +66,7 @@
             $.each($('.selectedActions .menu-center li:not(.hidden)'), function (i, selectedAction) {
                 var action = $(selectedAction);
 
-                addNewOption(action.attr('class'), $(action.find('span.icon')).attr('class').replace('icon', '').replace(' ', '').replace('icon-', ''), $(action.find('span:not(.icon)')).text(), function () {
+                addNewOption(action.attr('class'), $(action.find('span.icon')).attr('class').replace('icon', '').replace(' ', '').replace('icon-', ''), $(action.find('span')).text(), function () {
                     action.find('a').click();
                 }, false);
             });


### PR DESCRIPTION
<details>
<summary>For my own testing</summary>

```
docker run -it \
--name nextcloud-easy-test \
-p 8443:443 \
-e TRUSTED_DOMAIN=192.168.24.128 \
--volume="nextcloud_easy_test_npm_cache_volume:/var/www/.npm" \
-e SERVER_BRANCH=master \
-e RIGHTCLICK_BRANCH=enh/noid/fix-right-click-open-locally \
ghcr.io/szaimen/nextcloud-easy-test:latest
```

</details>